### PR TITLE
update to PXF 2.3.0.0. Fix the compilation issues due to API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build
 /accumulo-pxf-ext/doc
 /json-pxf-ext/doc
 /pxf-test/doc
+
+/external-jars
+/Servers
+/RemoteSystemsTempFiles

--- a/accumulo-pxf-ext/pom.xml
+++ b/accumulo-pxf-ext/pom.xml
@@ -7,7 +7,7 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-test-version>2.0.1.0-0</pxf-test-version>
+		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
 	<repositories>

--- a/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloAccessor.java
+++ b/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloAccessor.java
@@ -40,13 +40,13 @@ public class AccumuloAccessor extends Plugin implements ReadAccessor {
 	public AccumuloAccessor(InputData inputData) throws Exception {
 		super(inputData);
 
-		tableName = inputData.getProperty("X-GP-DATA-DIR");
+		tableName = inputData.getParametersMap().get("X-GP-DATA-DIR");
 		tableName = tableName.startsWith("/") ? tableName.substring(1)
 				: tableName;
-		instanceName = inputData.getProperty("X-GP-INSTANCE");
-		zooKeepers = inputData.getProperty("X-GP-QUORUM");
-		principal = inputData.getProperty("X-GP-USER");
-		token = new PasswordToken(inputData.getProperty("X-GP-PASSWORD"));
+		instanceName = inputData.getParametersMap().get("X-GP-INSTANCE");
+		zooKeepers = inputData.getParametersMap().get("X-GP-QUORUM");
+		principal = inputData.getParametersMap().get("X-GP-USER");
+		token = new PasswordToken(inputData.getParametersMap().get("X-GP-PASSWORD"));
 		jobConf = new JobConf(conf, AccumuloAccessor.class);
 
 		AccumuloInputFormat.setConnectorInfo(jobConf, principal, token);

--- a/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloFragmenter.java
+++ b/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloFragmenter.java
@@ -57,12 +57,12 @@ public class AccumuloFragmenter extends Fragmenter {
 	public AccumuloFragmenter(InputData meta) throws Exception {
 		super(meta);
 
-		instanceName = meta.getProperty("X-GP-INSTANCE");
-		zooKeepers = meta.getProperty("X-GP-QUORUM");
-		principal = meta.getProperty("X-GP-USER");
-		token = new PasswordToken(meta.getProperty("X-GP-PASSWORD"));
+		instanceName = meta.getParametersMap().get("X-GP-INSTANCE");
+		zooKeepers = meta.getParametersMap().get("X-GP-QUORUM");
+		principal = meta.getParametersMap().get("X-GP-USER");
+		token = new PasswordToken(meta.getParametersMap().get("X-GP-PASSWORD"));
 		jobConf = new JobConf();
-		auths = new Authorizations(meta.getProperty("X-GP-AUTHS"));
+		auths = new Authorizations(meta.getParametersMap().get("X-GP-AUTHS"));
 
 		AccumuloInputFormat.setConnectorInfo(jobConf, principal, token);
 		AccumuloInputFormat.setScanAuthorizations(jobConf, auths);
@@ -76,7 +76,7 @@ public class AccumuloFragmenter extends Fragmenter {
 	@Override
 	public List<Fragment> getFragments() throws Exception {
 
-		String datapath = this.inputData.path();
+		String datapath = this.inputData.getDataSource();
 
 		datapath = datapath.replaceFirst("^/", "");
 

--- a/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloResolver.java
+++ b/accumulo-pxf-ext/src/main/java/com/pivotal/pxf/plugins/accumulo/AccumuloResolver.java
@@ -27,7 +27,7 @@ public class AccumuloResolver extends Plugin implements ReadResolver {
 		Map<String, byte[]> keyValues = (Map<String, byte[]>) paramOneRow
 				.getData();
 
-		for (int i = 0; i < this.inputData.columns(); ++i) {
+		for (int i = 0; i < this.inputData.getColumns(); ++i) {
 			ColumnDescriptor column = (ColumnDescriptor) this.inputData
 					.getColumn(i);
 

--- a/cassandra-pxf-ext/pom.xml
+++ b/cassandra-pxf-ext/pom.xml
@@ -7,7 +7,7 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-test-version>2.0.1.0-0</pxf-test-version>
+		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
 	<repositories>

--- a/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraAccessor.java
+++ b/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraAccessor.java
@@ -35,10 +35,10 @@ public class CassandraAccessor extends Plugin implements ReadAccessor {
 	public CassandraAccessor(InputData inputData) throws Exception {
 		super(inputData);
 
-		keyspaceName = inputData.getProperty("X-GP-DATA-DIR");
-		address = inputData.getProperty("X-GP-ADDRESS");
-		columnFamily = inputData.getProperty("X-GP-COLUMN-FAMILY");
-		partitioner = inputData.getProperty("X-GP-PARTITIONER");
+		keyspaceName = inputData.getParametersMap().get("X-GP-DATA-DIR");
+		address = inputData.getParametersMap().get("X-GP-ADDRESS");
+		columnFamily = inputData.getParametersMap().get("X-GP-COLUMN-FAMILY");
+		partitioner = inputData.getParametersMap().get("X-GP-PARTITIONER");
 		jobConf = new JobConf(conf, CassandraAccessor.class);
 
 		ConfigHelper.setInputColumnFamily(jobConf, keyspaceName, columnFamily);

--- a/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraFragmenter.java
+++ b/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraFragmenter.java
@@ -25,9 +25,9 @@ public class CassandraFragmenter extends Fragmenter {
 	public CassandraFragmenter(InputData meta) throws Exception {
 		super(meta);
 
-		address = meta.getProperty("X-GP-ADDRESS");
-		columnFamily = meta.getProperty("X-GP-COLUMN-FAMILY");
-		partitioner = meta.getProperty("X-GP-PARTITIONER");
+		address = meta.getParametersMap().get("X-GP-ADDRESS");
+		columnFamily = meta.getParametersMap().get("X-GP-COLUMN-FAMILY");
+		partitioner = meta.getParametersMap().get("X-GP-PARTITIONER");
 		jobConf = new JobConf();
 
 		ConfigHelper.setInputInitialAddress(jobConf, address);
@@ -45,7 +45,7 @@ public class CassandraFragmenter extends Fragmenter {
 	@Override
 	public List<Fragment> getFragments() throws Exception {
 
-		keyspaceName = inputData.path();
+		keyspaceName = inputData.getDataSource();
 
 		ConfigHelper.setInputColumnFamily(jobConf, keyspaceName, columnFamily);
 

--- a/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraResolver.java
+++ b/cassandra-pxf-ext/src/main/java/com/pivotal/pxf/plugins/cassandra/CassandraResolver.java
@@ -33,7 +33,7 @@ public class CassandraResolver extends Plugin implements ReadResolver {
 		SortedMap<ByteBuffer, IColumn> keyValues = (SortedMap<ByteBuffer, IColumn>) onerow
 				.getData();
 
-		for (int i = 0; i < this.inputData.columns(); ++i) {
+		for (int i = 0; i < this.inputData.getColumns(); ++i) {
 			ColumnDescriptor column = (ColumnDescriptor) this.inputData
 					.getColumn(i);
 

--- a/hive-hotfix-pxf-ext/pom.xml
+++ b/hive-hotfix-pxf-ext/pom.xml
@@ -8,8 +8,8 @@
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
 		<hive-version>0.12.0-gphd-3.0.1.0</hive-version>
-		<pxf-version>2.2.0.0</pxf-version>
-		<pxf-test-version>2.0.1.0-0</pxf-test-version>
+		<pxf-version>2.3.0.0</pxf-version>
+		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
 	<repositories>

--- a/jdbc-pxf-ext/.classpath
+++ b/jdbc-pxf-ext/.classpath
@@ -24,6 +24,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="/usr/lib/gphd/gfxd/lib/gemfirexd-client.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/jdbc-pxf-ext/pom.xml
+++ b/jdbc-pxf-ext/pom.xml
@@ -7,7 +7,7 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-version>2.2.0.0</pxf-version>
+		<pxf-version>2.3.0.0</pxf-version>
 		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 

--- a/jdbc-pxf-ext/src/main/java/com/pivotal/pxf/plugins/jdbc/JdbcResolver.java
+++ b/jdbc-pxf-ext/src/main/java/com/pivotal/pxf/plugins/jdbc/JdbcResolver.java
@@ -26,7 +26,7 @@ public class JdbcResolver extends Plugin implements WriteResolver {
 
 	public JdbcResolver(InputData input) {
 		super(input);
-		TABLE_NAME = input.getProperty("X-GP-TABLE_NAME");
+		TABLE_NAME = input.getParametersMap().get("X-GP-TABLE_NAME");
 	}
 
 	@Override

--- a/jdbc-pxf-ext/src/test/java/com/pivotal/pxf/plugins/jdbc/JdbcMySqlExtensionTest.java
+++ b/jdbc-pxf-ext/src/test/java/com/pivotal/pxf/plugins/jdbc/JdbcMySqlExtensionTest.java
@@ -1,16 +1,13 @@
 package com.pivotal.pxf.plugins.jdbc;
 
 import java.io.IOException;
-import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.sql.ResultSet;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -18,12 +15,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.pivotal.pxf.PxfUnit;
-import com.pivotal.pxf.PxfUnit.Pair;
-import com.pivotal.pxf.api.Fragmenter;
 import com.pivotal.pxf.api.OneField;
 import com.pivotal.pxf.api.OneRow;
-import com.pivotal.pxf.api.ReadAccessor;
-import com.pivotal.pxf.api.ReadResolver;
 import com.pivotal.pxf.api.WriteAccessor;
 import com.pivotal.pxf.api.WriteResolver;
 import com.pivotal.pxf.api.io.DataType;
@@ -34,7 +27,7 @@ public class JdbcMySqlExtensionTest extends PxfUnit {
 	private JdbcResolver resolver = null;
 	private static final String JDBC_DRIVER = "com.mysql.jdbc.Driver";
 	private static final String DATABASE = "PXFTEST";
-	private static final String JDBC_CONNECTION = "jdbc:mysql://localhost:3306";
+	private static final String JDBC_CONNECTION = "jdbc:mysql://pcc:3306";
 	private static final String DB_URL = JDBC_CONNECTION + "/" + DATABASE;
 	private static final String TABLE_NAME = "PXFTEST";
 	private static final String POWER_USER = "root";

--- a/json-pxf-ext/pom.xml
+++ b/json-pxf-ext/pom.xml
@@ -7,8 +7,8 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-version>2.2.0.0</pxf-version>
-		<pxf-test-version>2.0.1.0-0</pxf-test-version>
+		<pxf-version>2.3.0.0</pxf-version>
+		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
 	<repositories>

--- a/json-pxf-ext/src/main/java/com/pivotal/pxf/plugins/json/JsonAccessor.java
+++ b/json-pxf-ext/src/main/java/com/pivotal/pxf/plugins/json/JsonAccessor.java
@@ -29,12 +29,12 @@ public class JsonAccessor extends HdfsSplittableDataAccessor {
 		super(inputData, new JsonInputFormat());
 
 		if (inputData.getParametersMap().containsKey(IDENTIFIER_PARAM)) {
-			identifier = inputData.getProperty(IDENTIFIER_PARAM);
+			identifier = inputData.getParametersMap().get(IDENTIFIER_PARAM);
 		}
 
 		if (inputData.getParametersMap().containsKey(ONERECORDPERLINE_PARAM)) {
 			oneRecordPerLine = Boolean.parseBoolean(inputData
-					.getProperty(ONERECORDPERLINE_PARAM));
+					.getParametersMap().get(ONERECORDPERLINE_PARAM));
 		}
 	}
 

--- a/json-pxf-ext/src/main/java/com/pivotal/pxf/plugins/json/JsonResolver.java
+++ b/json-pxf-ext/src/main/java/com/pivotal/pxf/plugins/json/JsonResolver.java
@@ -42,7 +42,7 @@ public class JsonResolver extends Plugin implements ReadResolver {
 		// if we weren't given a null object
 		if (root != null) {
 			// Iterate through the column definition and fetch our JSON data
-			for (int i = 0; i < inputData.columns(); ++i) {
+			for (int i = 0; i < inputData.getColumns(); ++i) {
 
 				// Get the current column description
 				ColumnDescriptor cd = inputData.getColumn(i);

--- a/pxf-pipes/pom.xml
+++ b/pxf-pipes/pom.xml
@@ -8,7 +8,7 @@
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
 		<pmr-common-version>2.0.1.0-1</pmr-common-version>
-		<pxf-version>2.2.0.0</pxf-version>
+		<pxf-version>2.3.0.0</pxf-version>
 		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
@@ -77,7 +77,7 @@
 			<artifactId>hadoop-streaming</artifactId>
 			<version>${hadoop-version}</version>
 		</dependency>
-		<dependency>
+		<dependency> 
 			<groupId>com.gopivotal</groupId>
 			<artifactId>pmr-common</artifactId>
 			<version>${pmr-common-version}</version>

--- a/pxf-pipes/src/main/java/com/pivotal/pxf/plugins/pipes/PxfPipesUtil.java
+++ b/pxf-pipes/src/main/java/com/pivotal/pxf/plugins/pipes/PxfPipesUtil.java
@@ -11,7 +11,7 @@ public class PxfPipesUtil {
 	public static Configuration conf = new Configuration();
 
 	public static String getMapperCommand(InputData input) {
-		return input.getProperty("X-GP-MAPPER");
+		return input.getParametersMap().get("X-GP-MAPPER");
 	}
 
 	public static boolean isLineByLine(InputData input) {

--- a/pxf-pipes/src/main/java/com/pivotal/pxf/plugins/pipes/WholeFileFragmenter.java
+++ b/pxf-pipes/src/main/java/com/pivotal/pxf/plugins/pipes/WholeFileFragmenter.java
@@ -28,7 +28,7 @@ public class WholeFileFragmenter extends Fragmenter {
 			IllegalAccessException {
 		super(data);
 
-		inputPath = new Path(data.path());
+		inputPath = new Path(data.getDataSource());
 
 		format = new WholeFileInputFormat();
 	}

--- a/pxf-test/pom.xml
+++ b/pxf-test/pom.xml
@@ -14,7 +14,7 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-version>2.2.0.0</pxf-version>
+		<pxf-version>2.3.0.0</pxf-version>
 	</properties>
 
 
@@ -48,7 +48,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.gopivotal</groupId>
-			<artifactId>pxf-core</artifactId>
+			<artifactId>pxf-service</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>
 		<dependency>

--- a/pxf-test/src/main/java/com/pivotal/pxf/PxfUnit.java
+++ b/pxf-test/src/main/java/com/pivotal/pxf/PxfUnit.java
@@ -32,7 +32,8 @@ import com.pivotal.pxf.api.WriteAccessor;
 import com.pivotal.pxf.api.WriteResolver;
 import com.pivotal.pxf.api.io.DataType;
 import com.pivotal.pxf.api.utilities.InputData;
-import com.pivotal.pxf.core.FragmentsResponseFormatter;
+import com.pivotal.pxf.service.FragmentsResponseFormatter;
+import com.pivotal.pxf.service.utilities.ProtocolData;
 
 /**
  * This abstract class contains a number of helpful utilities in developing a
@@ -290,7 +291,7 @@ public abstract class PxfUnit {
 			}
 		}
 
-		return new InputData(paramsMap);
+		return new ProtocolData(paramsMap);
 	}
 
 	/**
@@ -658,16 +659,16 @@ public abstract class PxfUnit {
 	 * Leveraged by the PXFUnit framework. Do not concern yourself with such a
 	 * simple piece of code.
 	 */
-	public static class LocalInputData extends InputData {
+	public static class LocalInputData extends ProtocolData {
 
-		public LocalInputData(InputData copy) {
+		public LocalInputData(ProtocolData copy) {
 			super(copy);
-			super.path = super.path().substring(1);
+			super.setDataSource(super.getDataSource().substring(1));
 		}
 
 		public LocalInputData(Map<String, String> paramsMap) {
 			super(paramsMap);
-			super.path = super.path().substring(1);
+			super.setDataSource(super.getDataSource().substring(1));
 		}
 	}
 }

--- a/redis-pxf-ext/pom.xml
+++ b/redis-pxf-ext/pom.xml
@@ -7,7 +7,7 @@
 
 	<properties>
 		<hadoop-version>2.2.0-gphd-3.0.1.0</hadoop-version>
-		<pxf-test-version>2.0.1.0-0</pxf-test-version>
+		<pxf-test-version>2.0.1.0-1</pxf-test-version>
 	</properties>
 
 	<repositories>

--- a/redis-pxf-ext/src/main/java/com/pivotal/pxf/plugins/redis/Parameters.java
+++ b/redis-pxf-ext/src/main/java/com/pivotal/pxf/plugins/redis/Parameters.java
@@ -15,7 +15,7 @@ public class Parameters {
 	public Parameters(InputData inputData) throws MissingArgumentException {
 
 		if (inputData.getParametersMap().containsKey(Parameters.HOSTS_PARAM)) {
-			hostString = inputData.getProperty(Parameters.HOSTS_PARAM);
+			hostString = inputData.getParametersMap().get(Parameters.HOSTS_PARAM);
 			hosts = hostString.split(",");
 		} else {
 			throw new MissingArgumentException(Parameters.HOSTS_PARAM
@@ -23,7 +23,7 @@ public class Parameters {
 		}
 
 		if (inputData.getParametersMap().containsKey(Parameters.HASHKEY_PARAM)) {
-			hashKey = inputData.getProperty(Parameters.HASHKEY_PARAM);
+			hashKey = inputData.getParametersMap().get(Parameters.HASHKEY_PARAM);
 		} else {
 			throw new MissingArgumentException(Parameters.HASHKEY_PARAM
 					+ " is not defined.");

--- a/redis-pxf-ext/src/main/java/com/pivotal/pxf/plugins/redis/RedisHashAccessor.java
+++ b/redis-pxf-ext/src/main/java/com/pivotal/pxf/plugins/redis/RedisHashAccessor.java
@@ -31,7 +31,7 @@ public class RedisHashAccessor extends Plugin implements ReadAccessor {
 	@Override
 	public boolean openForRead() throws Exception {
 
-		String host = inputData.path().replace("/", "");
+		String host = inputData.getDataSource().replace("/", "");
 
 		if (!host.contains(":")) {
 			readClient = new Jedis(host);


### PR DESCRIPTION
Update to the PXF 2.3.0.0 shiped with PHD2.1
There are couple of API changes that breaks compatibility. 

I had to install most of the haqw/pxf dependences to my local maven repo like this: 
mvn install:install-file -Dfile=pxf-hdfs-2.3.0.0.jar -DgroupId=com.gopivotal -DartifactId=pxf-hdfs -Dversion=2.3.0.0 -Dpackaging=jar
mvn install:install-file -Dfile=pxf-api-2.3.0.0.jar -DgroupId=com.gopivotal -DartifactId=pxf-api -Dversion=2.3.0.0 -Dpackaging=jar
mvn install:install-file -Dfile=pxf-service-2.3.0.0.jar -DgroupId=com.gopivotal -DartifactId=pxf-service -Dversion=2.3.0.0 -Dpackaging=jar


mvn install:install-file -Dfile=hawq-hadoop-javadoc.jar -DgroupId=com.gopivotal -DartifactId=hawq-hadoop-javadoc -Dversion=1.2.1.0 -Dpackaging=jar
mvn install:install-file -Dfile=hawq-mapreduce-ao.jar -DgroupId=com.gopivotal -DartifactId=hawq-mapreduce-ao -Dversion=1.2.1.0 -Dpackaging=jar
mvn install:install-file -Dfile=hawq-mapreduce-common.jar -DgroupId=com.gopivotal -DartifactId=hawq-mapreduce-common -Dversion=1.2.1.0 -Dpackaging=jar
mvn install:install-file -Dfile=hawq-mapreduce-parquet-tests.jar -DgroupId=com.gopivotal -DartifactId=hawq-mapreduce-parquet-tests -Dversion=1.2.1.0 -Dpackaging=jar
mvn install:install-file -Dfile=hawq-mapreduce-parquet.jar -DgroupId=com.gopivotal -DartifactId=hawq-mapreduce-parquet -Dversion=1.2.1.0 -Dpackaging=jar
mvn install:install-file -Dfile=hawq-mapreduce-tool.jar -DgroupId=com.gopivotal -DartifactId=hawq-mapreduce-tool -Dversion=1.2.1.0 -Dpackaging=jar

Also I had to build the pmr-common project with the newer as well.  