### PR TITLE
Replace the PXF github hosted maven repo by Bintry.com PXF maven repo

### DIFF
--- a/accumulo-pxf-ext/pom.xml
+++ b/accumulo-pxf-ext/pom.xml
@@ -86,6 +86,16 @@
 			<name>SpringSource Maven Release Repository</name>
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>
+		<repository>
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>		
 	</repositories>
 
 	<distributionManagement>

--- a/cassandra-pxf-ext/pom.xml
+++ b/cassandra-pxf-ext/pom.xml
@@ -91,6 +91,16 @@
 			<name>SpringSource Maven Release Repository</name>
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>
+		<repository>
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>		
 	</repositories>
 
 	<distributionManagement>

--- a/hive-hotfix-pxf-ext/pom.xml
+++ b/hive-hotfix-pxf-ext/pom.xml
@@ -70,10 +70,15 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>		
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>

--- a/jdbc-pxf-ext/pom.xml
+++ b/jdbc-pxf-ext/pom.xml
@@ -44,10 +44,15 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>		
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>	
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>

--- a/json-pxf-ext/pom.xml
+++ b/json-pxf-ext/pom.xml
@@ -109,11 +109,16 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>		
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>		
-	</repositories>
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
+    </repositories>
 
 	<distributionManagement>
 		<repository>

--- a/pxf-pipes/pom.xml
+++ b/pxf-pipes/pom.xml
@@ -141,10 +141,15 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>		
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>		
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>

--- a/pxf-test/pom.xml
+++ b/pxf-test/pom.xml
@@ -77,10 +77,15 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>		
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>		
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>

--- a/redis-pxf-ext/pom.xml
+++ b/redis-pxf-ext/pom.xml
@@ -98,10 +98,15 @@
 			<url>http://repo.springsource.org/libs-release</url>
 		</repository>		
 		<repository>
-			<id>git-tzolov</id>
-			<name>tzolov's Git based repo</name>
-			<url>https://github.com/tzolov/maven-repo/raw/master/</url>
-		</repository>		
+		  <id>bintray-bigdata</id>
+		  <url>https://dl.bintray.com/big-data/maven</url>
+		  <releases>
+		    <enabled>true</enabled>
+		  </releases>
+		  <snapshots>
+		    <enabled>false</enabled>
+		  </snapshots>
+		</repository>
 	</repositories>
 
 	<distributionManagement>


### PR DESCRIPTION
Replace 
```
<repository>
   <id>git-tzolov</id>
   <name>tzolov's Git based repo</name>
   <url>https://github.com/tzolov/maven-repo/raw/master/</url>
</repository>	
```
By 
```
<repository>
   <id>bintray-bigdata</id>
   <url>https://dl.bintray.com/big-data/maven</url>
</repository>
```