### PR TITLE
Update to PXF 2.5.1.0

### DIFF
--- a/accumulo-pxf-ext/pom.xml
+++ b/accumulo-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>accumulo-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/accumulo-pxf-ext/pom.xml
+++ b/accumulo-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>accumulo-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/cassandra-pxf-ext/pom.xml
+++ b/cassandra-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>cassandra-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/cassandra-pxf-ext/pom.xml
+++ b/cassandra-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>cassandra-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/hive-hotfix-pxf-ext/pom.xml
+++ b/hive-hotfix-pxf-ext/pom.xml
@@ -3,13 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>hive-hotfix-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<hive-version>0.14.0.2.2.0.0-2041</hive-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/hive-hotfix-pxf-ext/pom.xml
+++ b/hive-hotfix-pxf-ext/pom.xml
@@ -3,13 +3,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>hive-hotfix-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<hive-version>0.14.0.2.2.0.0-2041</hive-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/hive-hotfix-pxf-ext/pom.xml
+++ b/hive-hotfix-pxf-ext/pom.xml
@@ -8,7 +8,7 @@
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<hive-version>0.14.0.2.2.0.0-2041</hive-version>
-		<pxf-version>2.5.0.0</pxf-version>
+		<pxf-version>2.5.1.0</pxf-version>
 		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
 	</properties>
 	
@@ -34,12 +34,12 @@
 			<version>${hive-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-hdfs</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-hive</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>

--- a/jdbc-pxf-ext/pom.xml
+++ b/jdbc-pxf-ext/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>jdbc-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/jdbc-pxf-ext/pom.xml
+++ b/jdbc-pxf-ext/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>jdbc-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/jdbc-pxf-ext/pom.xml
+++ b/jdbc-pxf-ext/pom.xml
@@ -6,7 +6,7 @@
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-version>2.5.0.0</pxf-version>
+		<pxf-version>2.5.1.0</pxf-version>
 		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
 	</properties>
 

--- a/json-pxf-ext/pom.xml
+++ b/json-pxf-ext/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>json-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/json-pxf-ext/pom.xml
+++ b/json-pxf-ext/pom.xml
@@ -2,12 +2,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>json-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/json-pxf-ext/pom.xml
+++ b/json-pxf-ext/pom.xml
@@ -6,7 +6,7 @@
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-version>2.5.0.0</pxf-version>
+		<pxf-version>2.5.1.0</pxf-version>
 		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
 	</properties>
 
@@ -32,7 +32,7 @@
 			<version>${hadoop-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-hdfs</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-modules</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 	<packaging>pom</packaging>
 
 	<scm>
 	  <connection>scm:git:https://github.com/tzolov/pxf-field.git</connection>
 	  <developerConnection>scm:git:git@github.com:tzolov/pxf-field.git</developerConnection>
 	  <url>https://github.com/tzolov/pxf-field</url>
-	  <tag>HEAD</tag>
+	  <tag>pxf-modules-3.0.0.0-18</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-modules</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<scm>
 	  <connection>scm:git:https://github.com/tzolov/pxf-field.git</connection>
 	  <developerConnection>scm:git:git@github.com:tzolov/pxf-field.git</developerConnection>
 	  <url>https://github.com/tzolov/pxf-field</url>
-	  <tag>pxf-modules-3.0.0.0-18</tag>
+	  <tag>HEAD</tag>
 	</scm>
 
 	<distributionManagement>

--- a/pxf-pipes/pom.xml
+++ b/pxf-pipes/pom.xml
@@ -7,7 +7,7 @@
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pmr-common-version>2.0.1.0-1</pmr-common-version>
-		<pxf-version>2.5.0.0</pxf-version>
+		<pxf-version>2.5.1.0</pxf-version>
 		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
 	</properties>
 	
@@ -43,7 +43,7 @@
 			<version>${pmr-common-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-service</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>

--- a/pxf-pipes/pom.xml
+++ b/pxf-pipes/pom.xml
@@ -2,13 +2,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-pipes</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pmr-common-version>2.0.1.0-1</pmr-common-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/pxf-pipes/pom.xml
+++ b/pxf-pipes/pom.xml
@@ -2,13 +2,13 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-pipes</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
 		<pmr-common-version>2.0.1.0-1</pmr-common-version>
 		<pxf-version>2.5.1.0</pxf-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 	
 	<dependencies>

--- a/pxf-test/pom.xml
+++ b/pxf-test/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-test</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>

--- a/pxf-test/pom.xml
+++ b/pxf-test/pom.xml
@@ -6,7 +6,7 @@
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-version>2.5.0.0</pxf-version>
+		<pxf-version>2.5.1.0</pxf-version>
 	</properties>	
 	
 	<dependencies>
@@ -16,17 +16,17 @@
 			<version>${hadoop-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-api</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-service</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.gopivotal</groupId>
+			<groupId>com.pivotal</groupId>
 			<artifactId>pxf-hdfs</artifactId>
 			<version>${pxf-version}</version>
 		</dependency>

--- a/pxf-test/pom.xml
+++ b/pxf-test/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>pxf-test</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>

--- a/pxf-test/src/main/java/com/pivotal/pxf/PxfUnit.java
+++ b/pxf-test/src/main/java/com/pivotal/pxf/PxfUnit.java
@@ -1,6 +1,7 @@
 package com.pivotal.pxf;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
@@ -32,6 +33,7 @@ import com.pivotal.pxf.api.WriteAccessor;
 import com.pivotal.pxf.api.WriteResolver;
 import com.pivotal.pxf.api.io.DataType;
 import com.pivotal.pxf.api.utilities.InputData;
+import com.pivotal.pxf.service.FragmentsResponse;
 import com.pivotal.pxf.service.FragmentsResponseFormatter;
 import com.pivotal.pxf.service.utilities.ProtocolData;
 
@@ -360,8 +362,13 @@ public abstract class PxfUnit {
 		List<Fragment> fragments = getFragmenter(fragmentInputData)
 				.getFragments();
 
-		String jsonOutput = FragmentsResponseFormatter.formatResponseString(
-				fragments, input.toString());
+		FragmentsResponse fragmentsResponse = FragmentsResponseFormatter
+				.formatResponse(fragments, input.toString());
+
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		fragmentsResponse.write(baos);
+
+		String jsonOutput = baos.toString();
 
 		inputs = new ArrayList<InputData>();
 

--- a/redis-pxf-ext/pom.xml
+++ b/redis-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>redis-pxf-ext</artifactId>
-	<version>3.0.0.0-18-SNAPSHOT</version>
+	<version>3.0.0.0-18</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18-SNAPSHOT</pxf-test-version>
+		<pxf-test-version>3.0.0.0-18</pxf-test-version>
 	</properties>
 
 	<dependencies>

--- a/redis-pxf-ext/pom.xml
+++ b/redis-pxf-ext/pom.xml
@@ -2,11 +2,11 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.gopivotal</groupId>
 	<artifactId>redis-pxf-ext</artifactId>
-	<version>3.0.0.0-18</version>
+	<version>3.0.0.0-19-SNAPSHOT</version>
 
 	<properties>
 		<hadoop-version>2.6.0.3.0.0.0-249</hadoop-version>
-		<pxf-test-version>3.0.0.0-18</pxf-test-version>
+		<pxf-test-version>3.0.0.0-19-SNAPSHOT</pxf-test-version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
> Note that the com.`gopivotal` group name is renamed to com.`pivotal`! 

The new dependencies look like this:
```xml
<dependency>
   <groupId>com.gopivotal</groupId>
   <artifactId>accumulo-pxf-ext</artifactId>
   <version>3.0.0.0-18</version>
</dependency>

<dependency>
   <groupId>com.gopivotal</groupId>
   <artifactId>cassandra-pxf-ext</artifactId>
   <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>hive-hotfix-pxf-ext</artifactId>
  <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>jdbc-pxf-ext</artifactId>
  <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>json-pxf-ext</artifactId>
  <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>pxf-pipes</artifactId>
  <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>pxf-test</artifactId>
  <version>3.0.0.0-18</version>
</dependency>

<dependency>
  <groupId>com.gopivotal</groupId>
  <artifactId>redis-pxf-ext</artifactId>
  <version>3.0.0.0-18</version>
</dependency>
```

